### PR TITLE
Bot.naturaltime should accept timestamps

### DIFF
--- a/ircbot/abstractbot.py
+++ b/ircbot/abstractbot.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import re
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import humanize
 
@@ -294,6 +294,8 @@ class AbstractBot:
             return humanize.naturaldelta(time)
         if isinstance(time, str):
             time = parse_time(time)
+        elif isinstance(time, (float, int)):
+            time = datetime.fromtimestamp(time)
         # Workaround for bug with timezone-aware datetime in humanize lib
         if time.tzinfo:
             time = time.replace(tzinfo=None)


### PR DESCRIPTION
This fixes the following issue:

```
Apr 29 15:17:52 applejack python[36411]:   File "/home/lechbot/lechbot/ircbot/ircbot.py", line 25, in _on_irc_message
Apr 29 15:17:52 applejack python[36411]:     self.feed(user.nick, target, text)
Apr 29 15:17:52 applejack python[36411]:   File "/home/lechbot/lechbot/ircbot/abstractbot.py", line 155, in feed
Apr 29 15:17:52 applejack python[36411]:     self.spawn(callback(Message(self, *evt)))
Apr 29 15:17:52 applejack python[36411]:   File "/home/lechbot/lechbot/plugins/topic.py", line 107, in tell_topic
Apr 29 15:17:52 applejack python[36411]:     when = self.bot.naturaltime(topic[key]["last_changed"])
Apr 29 15:17:52 applejack python[36411]:   File "/home/lechbot/lechbot/ircbot/abstractbot.py", line 298, in naturaltime
Apr 29 15:17:52 applejack python[36411]:     if time.tzinfo:
Apr 29 15:17:52 applejack python[36411]: AttributeError: 'float' object has no attribute 'tzinfo'
```
