### PR TITLE
Fixing title cookie problem

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -75,6 +75,7 @@ typing-extensions==3.7.4.3
     #   yarl
 yarl==1.6.3
     # via aiohttp
+youtube_dl==2021.5.16
 zipp==3.4.1
     # via
     #   importlib-metadata


### PR DESCRIPTION
Changement du parseur HTML vers celui de youtube-dl (qui est maintenu assez régulièrement et supporte beaucoup de plateformes)
Fixes #63 