### PR TITLE
Add support for bridge bots

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,6 +8,9 @@ PORT = 6697
 # Main chan for this bot
 MAIN_CHAN = "#titoufaitdestests"
 
+# IRC<->otherIM bridge bots
+BRIDGE_BOTS = ["LeBID"]
+
 # Url to Incubator
 INCUBATOR = "http://localhost:8000/"
 

--- a/ircbot/abstractbot.py
+++ b/ircbot/abstractbot.py
@@ -73,7 +73,9 @@ class AbstractBot:
         purple = staticmethod(make_style("<purple>", "</purple>"))
         grey = staticmethod(make_style("<grey>", "</grey>"))
 
-    def __init__(self, nickname, channels={}, bridge_bots=set(), main_chan=None, local_only=False):
+    def __init__(
+        self, nickname, channels={}, bridge_bots=set(), main_chan=None, local_only=False
+    ):
         """
         Create a new bot.
 
@@ -154,7 +156,7 @@ class AbstractBot:
         # If this is the case, extract the original author and text that was
         # sent on the other side of the bridge, and use them as user and text
         if user in self.bridge_bots:
-            match = re.match(r'^\s*<\s*([^>]+)\s*>\s*(.+)', text)
+            match = re.match(r"^\s*<\s*([^>]+)\s*>\s*(.+)", text)
             if match:
                 user = match.group(1)
                 text = match.group(2)

--- a/lechbot.py
+++ b/lechbot.py
@@ -6,7 +6,7 @@ import humanize
 import sentry_sdk
 
 from chanconfig import CHANS
-from config import MAIN_CHAN, NICKNAME, PORT, SENTRY_DSN, SERVER
+from config import MAIN_CHAN, NICKNAME, PORT, SENTRY_DSN, SERVER, BRIDGE_BOTS
 from ircbot import CLIBot, IRCBot
 
 
@@ -18,7 +18,7 @@ def main(loglevel, klass, options):
     if SENTRY_DSN:
         sentry_sdk.init(SENTRY_DSN, traces_sample_rate=1.0)
 
-    bot = klass(NICKNAME, CHANS, main_chan=MAIN_CHAN, local_only=options.local)
+    bot = klass(NICKNAME, CHANS, bridge_bots=BRIDGE_BOTS, main_chan=MAIN_CHAN, local_only=options.local)
 
     @bot.command(r"tg %s$" % NICKNAME)
     def shut_up(msg):

--- a/lechbot.py
+++ b/lechbot.py
@@ -18,7 +18,13 @@ def main(loglevel, klass, options):
     if SENTRY_DSN:
         sentry_sdk.init(SENTRY_DSN, traces_sample_rate=1.0)
 
-    bot = klass(NICKNAME, CHANS, bridge_bots=BRIDGE_BOTS, main_chan=MAIN_CHAN, local_only=options.local)
+    bot = klass(
+        NICKNAME,
+        CHANS,
+        bridge_bots=BRIDGE_BOTS,
+        main_chan=MAIN_CHAN,
+        local_only=options.local,
+    )
 
     @bot.command(r"tg %s$" % NICKNAME)
     def shut_up(msg):


### PR DESCRIPTION
On #UrLab, we have the bot LeBID (Le Bridge-IRC-Discord). As its name
suggests, if shares the messages between IRC and Discord. When arriving on IRC
the messages are in the form: `<DiscordUser> text that was sent on Discord`.

Because of this, many LechBot handlers are not triggered, because they expect
the text to start with the command directly (like `!motd ...`), and as such
some commands are unavailable to Discord users.

We therefore add a mechanism when a new message is received, such that if a
known bridge bot sent the message, we extract the original user and text before
processing it like any other IRC message.
