### PR TITLE
Bump aiohttp to v3.8.3

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 git+https://github.com/titouanc/asyncirc
-aiohttp==3.8.1
+aiohttp
 aioauth-client
 humanize
 python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 aioauth-client==0.27.3
     # via -r requirements.in
-aiohttp==3.8.1
+aiohttp==3.8.3
     # via -r requirements.in
 aiosignal==1.3.1
     # via aiohttp


### PR DESCRIPTION
- Remove version constraint on aiohttp in requirements.in
- Bump aiohttp to v3.8.3

This superseeds #155
